### PR TITLE
Add Data Table Extension Methods

### DIFF
--- a/src/Benchmarks/Nebula.Data.Benchmarks/Nebula.Data.Benchmarks.csproj
+++ b/src/Benchmarks/Nebula.Data.Benchmarks/Nebula.Data.Benchmarks.csproj
@@ -8,14 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="BenchmarkResultHistory\CsvReader_FromCsv_20_05_2025.md" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Compile Include="BenchmarkResultHistory\CsvReader_FromCsv_20_05_2025.md" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageReference Include="Bogus" Version="35.6.3" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
@@ -26,6 +18,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Nebula.Data\Nebula.Data.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="BenchmarkResultHistory\" />
   </ItemGroup>
 
 </Project>

--- a/src/Nebula.Data/Extensions/DataTableExtensions.cs
+++ b/src/Nebula.Data/Extensions/DataTableExtensions.cs
@@ -1,0 +1,25 @@
+// <copyright file="DataTableExtensions.cs" company="Nebula">
+// Copyright © Nebula 2025
+// </copyright>
+
+namespace Nebula.Data.Extensions
+{
+    using Nebula.Data.Structures;
+
+    public static class DataTableExtensions
+    {
+        public static double[][] ToVectorMatrix(this DataTable dataTable, params string[] featureColumns)
+        {
+            return dataTable.GetFeatures(featureColumns)
+                        .Select(row => row.Select(Convert.ToDouble).ToArray())
+                        .ToArray();
+        }
+
+        public static T[] ToLabelVector<T>(this DataTable dataTable, string labelColumn)
+        {
+            return dataTable.GetTargets(labelColumn)
+                        .Select(value => (T)Convert.ChangeType(value, typeof(T)))
+                        .ToArray();
+        }
+    }
+}

--- a/src/Tests/Nebula.Data.UnitTests/Extensions/DataTableExtensionsTests.cs
+++ b/src/Tests/Nebula.Data.UnitTests/Extensions/DataTableExtensionsTests.cs
@@ -1,0 +1,53 @@
+// <copyright file="DataTableExtensionsTests.cs" company="Nebula">
+// Copyright © Nebula 2025
+// </copyright>
+
+namespace Nebula.Data.UnitTests.Extensions
+{
+    using FluentAssertions;
+    using Nebula.Data.Extensions;
+    using Nebula.Data.Structures;
+
+    public class DataTableExtensionsTests
+    {
+        private readonly DataTable _dataTable;
+
+        public DataTableExtensionsTests()
+        {
+            _dataTable = new DataTable(new List<Dictionary<string, object>>
+            {
+                new() { { "feature1", 0.5 }, { "feature2", 1.2 }, { "label", 1 } },
+                new() { { "feature1", 0.3 }, { "feature2", 1.6 }, { "label", 0 } },
+            });
+        }
+
+        [Fact]
+        public void ToVectorMatrix_ShouldConvertFeatureColumnsToMatrix()
+        {
+            // Act
+            var result = _dataTable.ToVectorMatrix("feature1", "feature2");
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Should().HaveCount(2);
+            result.Should().BeEquivalentTo(new[]
+            {
+                new[] { 0.5, 1.2 },
+                new[] { 0.3, 1.6 },
+            });
+        }
+
+        [Fact]
+        public void ToLabelVector_ShouldCovertColumnToTArray()
+        {
+            // Act
+            var result = _dataTable.ToLabelVector<int>("label");
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Should().BeOfType<int[]>();
+            result.Should().HaveCount(2);
+            result.Should().BeEquivalentTo(new[] { 1, 0 });
+        }
+    }
+}


### PR DESCRIPTION
Add extension methods to convert from data table to vector matrix and vector labels. These will be used to pass to the model for training.