### PR TITLE
linear regression model

### DIFF
--- a/src/Benchmarks/Nebula.ML.Benchmarks/Models/Regression/LinearRegressionBenchmarks.cs
+++ b/src/Benchmarks/Nebula.ML.Benchmarks/Models/Regression/LinearRegressionBenchmarks.cs
@@ -1,0 +1,53 @@
+// <copyright file="LinearRegressionBenchmarks.cs" company="Nebula">
+// Copyright © Nebula 2025
+// </copyright>
+
+namespace Nebula.ML.Benchmarks.Models.Regression
+{
+    using BenchmarkDotNet.Attributes;
+    using Nebula.ML.Models.Regression;
+
+    [MemoryDiagnoser]
+    public class LinearRegressionBenchmarks
+    {
+        [Params(100, 1000, 10000, 50000, 100000)]
+        public int SampleCount;
+
+        [Params(2, 5, 20, 50)]
+        public int FeatureCount;
+
+        private double[][] _features;
+        private double[] _labels;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            GenerateFakeData(SampleCount, FeatureCount);
+        }
+
+        [Benchmark(Description = "Trains the Linear Regression model over 100 epochs")]
+        public void Benchmark_Fit()
+        {
+            var model = new LinearRegression(null, 100);
+            model.Fit(_features, _labels);
+        }
+
+        private void GenerateFakeData(int sampleCount, int featureCount)
+        {
+            var random = new Random();
+            _features = new double[sampleCount][];
+            _labels = new double[sampleCount];
+
+            for (int i = 0; i < sampleCount; i++)
+            {
+                _features[i] = new double[featureCount];
+                for (int j = 0; j < featureCount; j++)
+                {
+                    _features[i][j] = random.NextDouble();
+                }
+
+                _labels[i] = 0.5 * _features[i][0] + 0.3 * (featureCount > 1 ? _features[i][1] : 0) + random.NextDouble() * 0.1;
+            }
+        }
+    }
+}

--- a/src/Nebula.Core/Activations/HeavisideStep.cs
+++ b/src/Nebula.Core/Activations/HeavisideStep.cs
@@ -8,15 +8,15 @@ namespace Nebula.Core.Activations
     /// The heaviside step activation function. Returns 0 for inputs less than threshold, and 1 for inputs greater than or equal to threshold.
     /// Default threshold is 0.5.
     /// </summary>
-    public class HeavisideStepActivation : IActivationFunction
+    public class HeavisideStep : IActivation
     {
         private readonly double _threshold;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="HeavisideStepActivation"/> class.
+        /// Initializes a new instance of the <see cref="HeavisideStep"/> class.
         /// </summary>
         /// <param name="threshold">The value that determines if the perceptron should "fire".</param>
-        public HeavisideStepActivation(double threshold = 0.5)
+        public HeavisideStep(double threshold = 0.5)
         {
             _threshold = threshold;
         }

--- a/src/Nebula.Core/Activations/IActivation.cs
+++ b/src/Nebula.Core/Activations/IActivation.cs
@@ -7,7 +7,7 @@ namespace Nebula.Core.Activations
     /// <summary>
     /// Defines the interface for activation functions.
     /// </summary>
-    public interface IActivationFunction
+    public interface IActivation
     {
         /// <summary>
         /// Determines the output of the activation function for a given input.

--- a/src/Nebula.Core/Activations/IdentityActivation.cs
+++ b/src/Nebula.Core/Activations/IdentityActivation.cs
@@ -1,0 +1,26 @@
+// <copyright file="IdentityActivation.cs" company="Nebula">
+// Copyright © Nebula 2025
+// </copyright>
+
+namespace Nebula.Core.Activations
+{
+    /// <summary>
+    /// An activation function that returns the input value unchanged.
+    /// </summary>
+    public class IdentityActivation : IActivation
+    {
+        /// <summary>
+        /// The identity activation function simply returns the input value.
+        /// </summary>
+        /// <param name="input">The input value.</param>
+        /// <returns>The input value unchanged f(x) = x.</returns>
+        public double Activate(double input) => input;
+
+        /// <summary>
+        /// Its derivative is 1 everywhere: f′(x) = 1.
+        /// </summary>
+        /// <param name="input">The input value.</param>
+        /// <returns>1.</returns>
+        public double Derivative(double input) => 1.0;
+    }
+}

--- a/src/Nebula.Core/Activations/SigmoidActivation.cs
+++ b/src/Nebula.Core/Activations/SigmoidActivation.cs
@@ -1,0 +1,35 @@
+// <copyright file="SigmoidActivation.cs" company="Nebula">
+// Copyright © Nebula 2025
+// </copyright>
+
+namespace Nebula.Core.Activations
+{
+    /// <summary>
+    /// Represents the logistic sigmoid activation function.
+    /// Sigmoid activation function squashes the input value and returns a value between 0 and 1.
+    /// </summary>
+    public class SigmoidActivation : IActivation
+    {
+        /// <summary>
+        /// Applies the sigmoid activation function to the input.
+        /// f(x) = 1 / (1 + exp(-x)).
+        /// </summary>
+        /// <param name="input">The input value.</param>
+        /// <returns>The activated output between 0 and 1.</returns>
+        public double Activate(double input)
+        {
+            return 1.0 / (1.0 + Math.Exp(-input));
+        }
+
+        /// <summary>
+        /// Computes the derivative: f′(x) = f(x) * (1 – f(x)).
+        /// </summary>
+        /// <param name="input">The input value.</param>
+        /// <returns>The slope of the sigmoid at input.</returns>
+        public double Derivative(double input)
+        {
+            var activatedValue = Activate(input);
+            return activatedValue * (1.0 - activatedValue);
+        }
+    }
+}

--- a/src/Tests/Nebula.Core.UnitTests/Activations/HeavisideStepActivationTests.cs
+++ b/src/Tests/Nebula.Core.UnitTests/Activations/HeavisideStepActivationTests.cs
@@ -17,7 +17,7 @@ namespace Nebula.Core.UnitTests.Activations
         public void Activate_ShouldReturnZero_GivenInputLessThanThreshold(double input, double threshold)
         {
             // Arrange
-            var activation = new HeavisideStepActivation(threshold);
+            var activation = new HeavisideStep(threshold);
 
             // Act
             double result = activation.Activate(input);
@@ -34,7 +34,7 @@ namespace Nebula.Core.UnitTests.Activations
         public void Activate_ShouldReturnOne_GivenInputLessThanThreshold(double input, double threshold)
         {
             // Arrange
-            var activation = new HeavisideStepActivation(threshold);
+            var activation = new HeavisideStep(threshold);
 
             // Act
             double result = activation.Activate(input);

--- a/src/Tests/Nebula.Core.UnitTests/Activations/SigmoidActivationTests.cs
+++ b/src/Tests/Nebula.Core.UnitTests/Activations/SigmoidActivationTests.cs
@@ -1,0 +1,48 @@
+// <copyright file="SigmoidActivationTests.cs" company="Nebula">
+// Copyright © Nebula 2025
+// </copyright>
+
+namespace Nebula.Core.UnitTests.Activations
+{
+    using FluentAssertions;
+    using Nebula.Core.Activations;
+
+    public class SigmoidActivationTests
+    {
+        [Theory]
+        [InlineData(-2)]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]    
+        public void Activate_ShouldReturnValueBetweenZeroAndOne(double input)
+        {
+            // Arrange
+            var activation = new SigmoidActivation();
+
+            // Act
+            double result = activation.Activate(input);
+
+            // Assert
+            result.Should().BeInRange(0.0, 1.0);
+        }
+
+        [Theory]
+        [InlineData(-2.0, 0.1049)]
+        [InlineData(-1.0, 0.1966)]
+        [InlineData(0.0, 0.2500)]
+        [InlineData(1.0, 0.1966)]
+        [InlineData(2.0, 0.1049)]
+        public void Derivative_ShouldReturnCorrectSlope(double input, double expectedSlope)
+        {
+            // Arrange
+            var activation = new SigmoidActivation();
+
+            // Act
+            double result = activation.Derivative(input);
+
+            // Assert
+            result.Should().BeApproximately(expectedSlope, 0.0001);
+        }
+    }
+}

--- a/src/Tests/Nebula.ML.UnitTests/Models/Regression/LinearRegressionTests.cs
+++ b/src/Tests/Nebula.ML.UnitTests/Models/Regression/LinearRegressionTests.cs
@@ -1,0 +1,125 @@
+// <copyright file="LinearRegressionTests.cs" company="Nebula">
+// Copyright © Nebula 2025
+// </copyright>
+
+namespace Nebula.ML.UnitTests.Models.Regression
+{
+    using FluentAssertions;
+    using Nebula.ML.Models.Regression;
+
+    public class LinearRegressionTests
+    {
+        private readonly LinearRegression _model;
+
+        public LinearRegressionTests()
+        {
+            _model = new LinearRegression(null, 10, 0.01);
+        }
+
+        [Fact]
+        public void Fit_ShouldThrowException_GivenFeaturesAreNull()
+        {
+            // Arrange
+            double[][] features = null;
+            double[] labels = { 1, 0, 1, 0 };
+
+            // Act
+            Action act = () => _model.Fit(features, labels);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Fit_ShouldThrowException_GivenLabelsAreNull()
+        {
+            // Arrange
+            double[][] features = new[] { new double[] { 1.0, 2.0 } };
+            double[] labels = null;
+
+            // Act
+            Action act = () => _model.Fit(features, labels);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Fit_ShouldThrowException_GivenFeaturesAreEmpty()
+        {
+            // Arrange
+            double[][] features = new double[0][];
+            double[] labels = { 1, 0, 1, 0 };
+
+            // Act
+            Action act = () => _model.Fit(features, labels);
+
+            // Assert
+            act.Should().Throw<ArgumentException>()
+                .WithMessage("Features and labels must not be empty and of the same length.");
+        }
+
+        [Fact]
+        public void Fit_ShouldThrowException_GivenLabelsAreEmpty()
+        {
+            // Arrange
+            double[][] features = new[] { new double[] { 1.0, 2.0 } };
+            double[] labels = new double[0];
+
+            // Act
+            Action act = () => _model.Fit(features, labels);
+
+            // Assert
+            act.Should().Throw<ArgumentException>()
+                .WithMessage("Features and labels must not be empty and of the same length.");
+        }
+
+        [Fact]
+        public void Fit_ShouldThrowException_GivenFeaturesAndLabelsMismatchLength()
+        {
+            // Arrange
+            double[][] features = new[] { new double[] { 1.0, 2.0 } };
+            double[] labels = { 1, 2, 3 };
+
+            // Act
+            Action act = () => _model.Fit(features, labels);
+
+            // Assert
+            act.Should().Throw<ArgumentException>()
+                .WithMessage("Features and labels must not be empty and of the same length.");
+        }
+
+        [Fact]
+        public void Fit_And_Predict_ShouldLearnSimpleLinearFunction()
+        {
+            // Arrange
+            const double slope = 3.0;
+            const double intercept = 2.0;
+            const int sampleCount = 100;
+            var rng = new Random(0);
+
+            var features = Enumerable.Range(0, sampleCount)
+                                     .Select(i => new[] { i / 10.0 })
+                                     .ToArray();
+
+            var labels = features
+                .Select(f => (slope * f[0]) + intercept + ((rng.NextDouble() * 0.1) - 0.05))
+                .ToArray();
+
+            var model = new LinearRegression(null, epochs: 500, learningRate: 0.01);
+
+            // Act
+            model.Fit(features, labels);
+
+            // Assert
+            var testPoints = new[] { 0.0, 3.0, 6.0, 9.0 };
+            foreach (var x in testPoints)
+            {
+                double actual = model.Predict(new[] { x });
+                double expected = (slope * x) + intercept;
+
+                actual.Should().BeApproximately(expected, 0.2);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Linear Regression Model

| Method                                               | SampleCount | FeatureCount | Mean          | Error         | StdDev        | Allocated |
|----------------------------------------------------- |------------ |------------- |--------------:|--------------:|--------------:|----------:|
| 'Trains the Linear Regression model over 100 epochs' | 100         | 2            |      72.47 us |      0.598 us |      0.530 us |     120 B |
| 'Trains the Linear Regression model over 100 epochs' | 100         | 5            |      88.27 us |      1.179 us |      1.103 us |     144 B |
| 'Trains the Linear Regression model over 100 epochs' | 100         | 20           |     203.05 us |      1.026 us |      0.960 us |     264 B |
| 'Trains the Linear Regression model over 100 epochs' | 100         | 50           |     571.22 us |      8.125 us |      7.600 us |     504 B |
| 'Trains the Linear Regression model over 100 epochs' | 1000        | 2            |     708.97 us |      1.031 us |      0.861 us |     120 B |
| 'Trains the Linear Regression model over 100 epochs' | 1000        | 5            |     847.53 us |      2.799 us |      2.481 us |     144 B |
| 'Trains the Linear Regression model over 100 epochs' | 1000        | 20           |   1,986.78 us |     13.158 us |     12.308 us |     266 B |
| 'Trains the Linear Regression model over 100 epochs' | 1000        | 50           |   5,626.94 us |     77.204 us |     72.216 us |     507 B |
| 'Trains the Linear Regression model over 100 epochs' | 10000       | 2            |   7,178.96 us |     32.191 us |     30.112 us |     123 B |
| 'Trains the Linear Regression model over 100 epochs' | 10000       | 5            |   8,438.33 us |     35.497 us |     33.204 us |     150 B |
| 'Trains the Linear Regression model over 100 epochs' | 10000       | 20           |  20,039.28 us |    277.385 us |    259.466 us |     276 B |
| 'Trains the Linear Regression model over 100 epochs' | 10000       | 50           |  57,204.39 us |    954.962 us |    893.272 us |     554 B |
| 'Trains the Linear Regression model over 100 epochs' | 50000       | 2            |  36,989.20 us |    716.163 us |  1,156.470 us |     147 B |
| 'Trains the Linear Regression model over 100 epochs' | 50000       | 5            |  44,746.97 us |    477.684 us |    446.826 us |     180 B |
| 'Trains the Linear Regression model over 100 epochs' | 50000       | 20           | 102,979.11 us |  1,191.476 us |  1,056.213 us |     344 B |
| 'Trains the Linear Regression model over 100 epochs' | 50000       | 50           | 294,197.06 us |  3,230.093 us |  7,862.493 us |     904 B |
| 'Trains the Linear Regression model over 100 epochs' | 100000      | 2            |  72,440.65 us |    597.359 us |    466.379 us |     177 B |
| 'Trains the Linear Regression model over 100 epochs' | 100000      | 5            |  86,377.20 us |    467.844 us |    414.732 us |     211 B |
| 'Trains the Linear Regression model over 100 epochs' | 100000      | 20           | 209,274.07 us |  1,828.147 us |  2,440.524 us |     397 B |
| 'Trains the Linear Regression model over 100 epochs' | 100000      | 50           | 720,270.45 us | 14,177.706 us | 12,568.167 us |     904 B |